### PR TITLE
Fix the case where JF_RELEASES_REPO is set.

### DIFF
--- a/build/gitlab/v2/.setup-jfrog-unix.yml
+++ b/build/gitlab/v2/.setup-jfrog-unix.yml
@@ -22,7 +22,7 @@
   - |
     if [ -z "${JF_RELEASES_REPO}" ]
     then
-        BASE_URL="https://releases.jfrog.io/artifactory"
+        BASE_URL="https://releases.jfrog.io/artifactory/jfrog-cli"
         AUTH_HEADER=""
         echo "Downloading directly from releases.jfrog.io..."
     else
@@ -42,9 +42,9 @@
     if echo "${OSTYPE}" | grep -q darwin; then
         CLI_OS="mac"
         if [[ $(uname -m) == 'arm64' ]]; then
-          URL="${BASE_URL}/jfrog-cli/v2-jf/${VERSION}/jfrog-cli-mac-arm64/jf"
+          URL="${BASE_URL}/v2-jf/${VERSION}/jfrog-cli-mac-arm64/jf"
         else
-          URL="${BASE_URL}/jfrog-cli/v2-jf/${VERSION}/jfrog-cli-mac-386/jf"
+          URL="${BASE_URL}/v2-jf/${VERSION}/jfrog-cli-mac-386/jf"
         fi
         FILE_NAME="jf"
     else
@@ -77,7 +77,7 @@
                 exit -1
                 ;;
         esac
-        URL="${BASE_URL}/jfrog-cli/v2-jf/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jf"
+        URL="${BASE_URL}/v2-jf/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jf"
         FILE_NAME="jf"
     fi
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---

Using GitLab Templates for JFrog did not work as described [here](https://docs.jfrog-applications.jfrog.io/ci-and-sdks/ci-integrations/gitlab-templates-for-jfrog) for "air-gapped" environments. The reason seems to be a bug in `build/gitlab/v2/.setup-jfrog-unix.yml`.

Only `build/gitlab/v2/.setup-jfrog-unix.yml` was changed and I tested it on my local GitLab/Artifactory instances.